### PR TITLE
Fix load of DL_EXTENSIONS under rbx

### DIFF
--- a/lib/bootscale/entry.rb
+++ b/lib/bootscale/entry.rb
@@ -3,7 +3,7 @@ module Bootscale
     DL_EXTENSIONS = [
       RbConfig::CONFIG['DLEXT'],
       RbConfig::CONFIG['DLEXT2'],
-    ].reject(&:empty?).map { |ext| ".#{ext}"}
+    ].reject { |ext| ext.nil? || ext.empty? }.map { |ext| ".#{ext}"}
     FEATURE_FILES = "**/*{#{DOT_RB},#{DL_EXTENSIONS.join(',')}}"
     NORMALIZE_NATIVE_EXTENSIONS = !DL_EXTENSIONS.include?(DOT_SO)
     ALTERNATIVE_NATIVE_EXTENSIONS_PATTERN = /\.(o|bundle|dylib)\z/


### PR DESCRIPTION
This PR fixes the bootstrapping process of bootscale under rubinius. It happened that while in MRI2 `RbConfig::CONFIG['DLEXT2']` returns `''`, in rbx-2.5.7 it returns `nil` instead.

Also, to make the rails application run, I had to comment out `gem 'rubysl', platforms: :rbx` and `gem 'pry-rails'` since the first one currently raises `undefined method``=~' for Pathname (NameError)` (check [this](http://stackoverflow.com/questions/20248350/migrating-to-rubinius)) while the second one raises `SystemStackError`.
