### PR TITLE
Nested bundle

### DIFF
--- a/lib/bootscale/entry.rb
+++ b/lib/bootscale/entry.rb
@@ -8,27 +8,26 @@ module Bootscale
     NORMALIZE_NATIVE_EXTENSIONS = !DL_EXTENSIONS.include?(DOT_SO)
     ALTERNATIVE_NATIVE_EXTENSIONS_PATTERN = /\.(o|bundle|dylib)\z/
     SLASH = '/'.freeze
+    BUNDLE_PATH = Bundler.bundle_path.cleanpath.to_s << SLASH
 
     def initialize(path)
-      @path = path.sub(/\/$/, '')
+      @path = Pathname.new(path).cleanpath
+      @absolute = @path.absolute?
+      warn "Bootscale: Cannot speedup load for relative path #{@path}" unless @absolute
+      @relative_slice = (@path.to_s.size + 1)..-1
+      @contains_bundle_path = BUNDLE_PATH.start_with?(@path.to_s)
     end
 
     def requireables
-      unless absolute = @path.start_with?(SLASH)
-        warn "Bootscale: Cannot speedup load for relative path #{@path}"
-      end
-      includes_vendor_bundle = @path.end_with?("vendor") && File.exist?("#{@path}/bundle")
-
-      relative_part = (@path.size + 1)..-1
       Dir[File.join(@path, REQUIREABLE_FILES)].each_with_object([]) do |absolute_path, all|
-        relative_path = absolute_path.slice(relative_part)
-        next if includes_vendor_bundle && relative_path.start_with?("bundle/")
+        next if @contains_bundle_path && absolute_path.start_with?(BUNDLE_PATH)
+        relative_path = absolute_path.slice(@relative_slice)
 
         if NORMALIZE_NATIVE_EXTENSIONS
           relative_path.sub!(ALTERNATIVE_NATIVE_EXTENSIONS_PATTERN, DOT_SO)
         end
 
-        all << [relative_path, (absolute ? absolute_path : :relative)]
+        all << [relative_path, (@absolute ? absolute_path : :relative)]
       end
     end
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -76,10 +76,17 @@ RSpec.describe Bootscale do
         $test << 3
 
         # rails.rb
+        require 'pathname'
         $LOAD_PATH << File.expand_path('vendor') # rails does that by default
         $LOAD_PATH << File.expand_path('lib') # making sure not everything with /bundle/ is ignored
         $LOAD_PATH << File.expand_path('vendor/bundle/gems/active_support-2.1.3')
         $test = []
+
+        module Bundler
+          def self.bundle_path
+            Pathname.new(File.expand_path('vendor/bundle/gems/'))
+          end
+        end
 
         require 'bootscale/setup'
 

--- a/spec/support/expect_script_helper.rb
+++ b/spec/support/expect_script_helper.rb
@@ -4,6 +4,7 @@ class ScriptOutput < RSpec::Matchers::BuiltIn::Output
     return false unless Proc === block
     @source = block.call
     @actual = @stream_capturer.capture lambda { run_example(@source) }
+    raise "Script exited with status: #{$?.exitstatus}, output:\n#{@actual}" unless $?.success?
     @expected ? values_match?(@expected, @actual) : captured?
   end
 
@@ -31,10 +32,7 @@ class ScriptOutput < RSpec::Matchers::BuiltIn::Output
         FileUtils.mkdir_p(File.dirname(file))
         File.write(file, code)
       end
-
-      unless system("ruby #{files.last.first} 2>&1")
-        raise "Script exited with status: #{$?.exitstatus}"
-      end
+      system("ruby #{files.last.first} 2>&1")
     end
   end
 end


### PR DESCRIPTION
Superset of #23

Uses `Bundler.bundle_path` instead of hardcoded values.

@grosser you are totally right. The worst is that I was handling this in the unpublished internal version of bootscale, and lost it in the extraction :/

Are you good with this version?
