### PR TITLE
use absolute paths

### DIFF
--- a/lib/bootscale/entry.rb
+++ b/lib/bootscale/entry.rb
@@ -14,11 +14,16 @@ module Bootscale
       @path = Pathname.new(path).cleanpath
       @absolute = @path.absolute?
       warn "Bootscale: Cannot speedup load for relative path #{@path}" unless @absolute
-      @relative_slice = (@path.to_s.size + 1)..-1
-      @contains_bundle_path = BUNDLE_PATH.start_with?(@path.to_s)
+
+      @path = (@path.exist? ? @path.realpath : nil)
+      if @path
+        @relative_slice = (@path.to_s.size + 1)..-1
+        @contains_bundle_path = BUNDLE_PATH.start_with?(@path.to_s)
+      end
     end
 
     def requireables
+      return [] unless @path
       Dir[File.join(@path, REQUIREABLE_FILES)].each_with_object([]) do |absolute_path, all|
         next if @contains_bundle_path && absolute_path.start_with?(BUNDLE_PATH)
         relative_path = absolute_path.slice(@relative_slice)

--- a/spec/cache_builder_spec.rb
+++ b/spec/cache_builder_spec.rb
@@ -16,4 +16,14 @@ RSpec.describe Bootscale::CacheBuilder do
     cache = subject.generate(['spec/dummy/app/controllers'])
     expect(cache).to eq "application_controller.rb" => :relative
   end
+
+  it "resolved symlinked paths" do
+    in_tmpdir do
+      FileUtils.mkdir("real")
+      FileUtils.ln_s("real", "fake")
+      File.write("real/file.rb", "RELA")
+      cache = subject.generate([File.expand_path("fake")])
+      expect(cache).to eq "file.rb" => File.expand_path("real/file.rb")
+    end
+  end
 end


### PR DESCRIPTION
having a load-path point to a symlinked folder means we get duplicate requires when
someone tries to load the full path manually

@byroot 
