### PR TITLE
Recomend to set the initialize before load_environment_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For Rails apps it means adding an initializer in `config/application.rb`:
 ```ruby
 module MyApp
   class Application < Rails::Application
-    initializer :regenerate_require_cache, after: :set_load_path do
+    initializer :regenerate_require_cache, before: :load_environment_config do
       Bootscale.regenerate
     end
   end


### PR DESCRIPTION
Even though `after: :set_load_path` is actually what we want, many other initializers are at this hook point, and it end up being executed after `load_environment_config`, which tend to make use of require.

cc @grosser just wanted to let you know.
