### PR TITLE
Add Troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ patches `require` + `autoload` to use these absolute paths, thereby avoiding hav
 
 Problem outlined in this [talk](https://www.youtube.com/watch?v=kwkbrOwLsZY)
 
+## Troubleshooting
+
+If you're experiencing problems with loading your application and are unable to successfully run `Bootscale.regenerate`, try deleting the `tmp/bootscale` folder.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/byroot/bootscale.


### PR DESCRIPTION
Hey! Thanks for this gem, it made a lot of difference for us. But as for me, I spent over an hour yesterday debugging why my app wouldn't load. I upgraded my Ruby and rubygems and no matter what I did I couldn't get the app running.

Here's the stacktrace I was getting if someone would be to search for similar thing:

```
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems.rb:13: warning: already initialized constant Gem::VERSION
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems.rb:13: warning: previous definition of VERSION was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/compatibility.rb:14: warning: already initialized constant Gem::GEM_PRELUDE_SUCKAGE
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/compatibility.rb:14: warning: previous definition of GEM_PRELUDE_SUCKAGE was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/compatibility.rb:34: warning: already initialized constant Gem::RubyGemsVersion
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/compatibility.rb:34: warning: previous definition of RubyGemsVersion was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/compatibility.rb:38: warning: already initialized constant Gem::RbConfigPriorities
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/compatibility.rb:38: warning: previous definition of RbConfigPriorities was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/compatibility.rb:59: warning: already initialized constant Gem::RubyGemsPackageVersion
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/compatibility.rb:59: warning: previous definition of RubyGemsPackageVersion was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/defaults.rb:3: warning: already initialized constant Gem::DEFAULT_HOST
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/defaults.rb:3: warning: previous definition of DEFAULT_HOST was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems.rb:117: warning: already initialized constant Gem::RUBYGEMS_DIR
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems.rb:117: warning: previous definition of RUBYGEMS_DIR was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems.rb:122: warning: already initialized constant Gem::WIN_PATTERNS
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems.rb:122: warning: previous definition of WIN_PATTERNS was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems.rb:131: warning: already initialized constant Gem::GEM_DEP_FILES
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems.rb:131: warning: previous definition of GEM_DEP_FILES was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems.rb:140: warning: already initialized constant Gem::REPOSITORY_SUBDIRECTORIES
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems.rb:140: warning: previous definition of REPOSITORY_SUBDIRECTORIES was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems.rb:152: warning: already initialized constant Gem::REPOSITORY_DEFAULT_GEM_SUBDIRECTORIES
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems.rb:152: warning: previous definition of REPOSITORY_DEFAULT_GEM_SUBDIRECTORIES was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems.rb:162: warning: already initialized constant Gem::LOADED_SPECS_MUTEX
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems.rb:182: warning: previous definition of LOADED_SPECS_MUTEX was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems.rb:1210: warning: already initialized constant Gem::MARSHAL_SPEC_DIR
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems.rb:1313: warning: previous definition of MARSHAL_SPEC_DIR was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/version.rb:157: warning: already initialized constant Gem::Version::VERSION_PATTERN
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/version.rb:157: warning: previous definition of VERSION_PATTERN was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/version.rb:158: warning: already initialized constant Gem::Version::ANCHORED_VERSION_PATTERN
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/version.rb:158: warning: previous definition of ANCHORED_VERSION_PATTERN was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/requirement.rb:17: warning: already initialized constant Gem::Requirement::OPS
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/requirement.rb:17: warning: previous definition of OPS was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/requirement.rb:27: warning: already initialized constant Gem::Requirement::SOURCE_SET_REQUIREMENT
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/requirement.rb:27: warning: previous definition of SOURCE_SET_REQUIREMENT was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/requirement.rb:30: warning: already initialized constant Gem::Requirement::PATTERN_RAW
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/requirement.rb:30: warning: previous definition of PATTERN_RAW was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/requirement.rb:35: warning: already initialized constant Gem::Requirement::PATTERN
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/requirement.rb:35: warning: previous definition of PATTERN was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/requirement.rb:40: warning: already initialized constant Gem::Requirement::DefaultRequirement
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/requirement.rb:40: warning: previous definition of DefaultRequirement was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/requirement.rb:284: warning: already initialized constant Gem::Version::Requirement
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/requirement.rb:284: warning: previous definition of Requirement was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/platform.rb:198: warning: already initialized constant Gem::Platform::RUBY
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/platform.rb:198: warning: previous definition of RUBY was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/platform.rb:204: warning: already initialized constant Gem::Platform::CURRENT
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/platform.rb:204: warning: previous definition of CURRENT was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/stub_specification.rb:9: warning: already initialized constant Gem::StubSpecification::PREFIX
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/stub_specification.rb:9: warning: previous definition of PREFIX was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/stub_specification.rb:11: warning: already initialized constant Gem::StubSpecification::OPEN_MODE
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/stub_specification.rb:11: warning: previous definition of OPEN_MODE was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/stub_specification.rb:22: warning: already initialized constant Gem::StubSpecification::StubLine::NO_EXTENSIONS
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/stub_specification.rb:22: warning: previous definition of NO_EXTENSIONS was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/stub_specification.rb:25: warning: already initialized constant Gem::StubSpecification::StubLine::REQUIRE_PATHS
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/stub_specification.rb:25: warning: previous definition of REQUIRE_PATHS was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/stub_specification.rb:35: warning: already initialized constant Gem::StubSpecification::StubLine::REQUIRE_PATH_LIST
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/stub_specification.rb:35: warning: previous definition of REQUIRE_PATH_LIST was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/specification.rb:49: warning: already initialized constant Gem::Specification::NONEXISTENT_SPECIFICATION_VERSION
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/specification.rb:49: warning: previous definition of NONEXISTENT_SPECIFICATION_VERSION was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/specification.rb:72: warning: already initialized constant Gem::Specification::CURRENT_SPECIFICATION_VERSION
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/specification.rb:72: warning: previous definition of CURRENT_SPECIFICATION_VERSION was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/specification.rb:78: warning: already initialized constant Gem::Specification::SPECIFICATION_VERSION_HISTORY
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/specification.rb:78: warning: previous definition of SPECIFICATION_VERSION_HISTORY was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/specification.rb:96: warning: already initialized constant Gem::Specification::MARSHAL_FIELDS
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/specification.rb:96: warning: previous definition of MARSHAL_FIELDS was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/specification.rb:105: warning: already initialized constant Gem::Specification::TODAY
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/specification.rb:105: warning: previous definition of TODAY was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/specification.rb:107: warning: already initialized constant Gem::Specification::LOAD_CACHE
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/specification.rb:107: warning: previous definition of LOAD_CACHE was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/specification.rb:160: warning: already initialized constant Gem::Specification::Dupable
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/specification.rb:160: warning: previous definition of Dupable was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/specification.rb:180: warning: already initialized constant Gem::Specification::NOT_FOUND
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/specification.rb:180: warning: previous definition of NOT_FOUND was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/specification.rb:840: warning: already initialized constant Gem::Specification::EMPTY
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/specification.rb:840: warning: previous definition of EMPTY was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/specification.rb:1722: warning: already initialized constant Gem::Specification::DateLike
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/specification.rb:1726: warning: previous definition of DateLike was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/specification.rb:1727: warning: already initialized constant Gem::Specification::DateTimeFormat
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/specification.rb:1731: warning: previous definition of DateTimeFormat was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/exceptions.rb:270: warning: already initialized constant Gem::UnsatisfiableDepedencyError
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/exceptions.rb:270: warning: previous definition of UnsatisfiableDepedencyError was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/util.rb:70: warning: already initialized constant Gem::Util::NULL_DEVICE
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/util.rb:70: warning: previous definition of NULL_DEVICE was here
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:12: warning: already initialized constant Kernel::RUBYGEMS_ACTIVATION_MONITOR
/Users/mrfoto/.rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:12: warning: previous definition of RUBYGEMS_ACTIVATION_MONITOR was here
```

Note - no occurence of bootscale anywhere. However, after deep debugging session I saw a trace including the bootscale gem and I immediately knew there was an issue there. Now, because I couldn't start my app, I couldn't regenerate the cache. And I've spent much more time that I wanted finding out just where the cache is stored.

I guess this is a reasonable thing to have in the README. Feel free to close this PR if you disagree.

BTW You should move your README Contributing section to a CONTRIBUTING.md file 😉 
