### PR TITLE
Fix race condition in FileStorage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - '1.9'
   - '2.0'
   - '2.1'
   - '2.2'

--- a/lib/bootscale/file_storage.rb
+++ b/lib/bootscale/file_storage.rb
@@ -1,4 +1,5 @@
 require 'digest/md5'
+require_relative 'utils'
 
 module Bootscale
   class FileStorage
@@ -14,7 +15,7 @@ module Bootscale
     def dump(load_path, cache)
       path = cache_path(load_path)
       FileUtils.mkdir_p(File.dirname(path))
-      File.write(path, Serializer.dump(cache), mode: 'wb+')
+      Utils.atomic_write(path) { |f| f.write(Serializer.dump(cache)) }
     end
 
     private

--- a/lib/bootscale/utils.rb
+++ b/lib/bootscale/utils.rb
@@ -1,0 +1,30 @@
+module Bootscale
+  module Utils
+    # Write to a file atomically. Useful for situations where you
+    # don't want other processes or threads to see half-written files.
+    #
+    #   Utils.atomic_write('important.file') do |file|
+    #     file.write('hello')
+    #   end
+    #
+    # Returns nothing.
+    def self.atomic_write(filename)
+      dirname, basename = File.split(filename)
+      basename = [
+          basename,
+          Thread.current.object_id,
+          Process.pid,
+          rand(1000000)
+      ].join('.'.freeze)
+      tmpname = File.join(dirname, basename)
+
+      File.open(tmpname, 'wb+') do |f|
+        yield f
+      end
+
+      File.rename(tmpname, filename)
+    ensure
+      File.delete(tmpname) if File.exist?(tmpname)
+    end
+  end
+end

--- a/spec/file_storage_spec.rb
+++ b/spec/file_storage_spec.rb
@@ -4,7 +4,7 @@ require 'bootscale/file_storage'
 RSpec.describe Bootscale::FileStorage do
   around { |test| in_tmpdir(&test) }
 
-  subject { Bootscale::FileStorage.new('tmp/bootscale') }
+  subject { Bootscale::FileStorage.new(Dir.pwd) }
 
   it "dumps via Marshal by default" do
     expect(Bootscale::FileStorage::Serializer).to eq Marshal
@@ -14,5 +14,19 @@ RSpec.describe Bootscale::FileStorage do
     hash = {"\xDE" => 'utf-8'}
     subject.dump(%w(foo), hash)
     expect(subject.load(%w(foo))).to be == hash
+  end
+
+  context 'concurrent' do
+    it 'should not read garbage' do
+      load_path = %w[foo].freeze
+      expect do
+        threads = 100.times.map do |i|
+          Thread.new(subject) do |storage|
+            i.odd? ? storage.load(load_path) : storage.dump(load_path, 'a' * 100_000)
+          end
+        end
+        threads.map(&:join)
+      end.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
There's a race condition when Bootscale tries to write serialized data
on disk when it's run in highly concurrent environment, for example, via
parallel_test command with big number of processes, or when many
workers starting in cold boot in production.

This commit adds exclusive lock for writing and shared lock for reading
serialized data.
