### PR TITLE
Hook into ActiveSupport::Dependency to accelerate search_for_file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@ rvm:
   - '2.1'
   - '2.2'
   - 2.3.0
-  - rbx-2
 before_install: gem install bundler -v 1.10.6
 

--- a/README.md
+++ b/README.md
@@ -14,16 +14,6 @@ but for bigger applications it can save 1 to 3 seconds of boot time per 100 used
 # Gemfile
 gem 'bootscale', require: false
 ```
-
-Then you need to add right after `require 'bundler/setup'`:
-
-```ruby
-require 'bundler/setup'
-require 'bootscale/setup'
-```
-
-If your application is a Rails application, you will find this in `config/boot.rb`.
-
 ### Important
 
 For correctness cache should be updated everytime `$LOAD_PATH` is modified by calling `Bootscale.regenerate`.
@@ -38,6 +28,22 @@ module MyApp
     end
   end
 end
+
+### Rails applications
+
+Locate `require 'bundler/setup'` in `config/boot.rb` and add `require 'bootscale/rails'` after it:
+```ruby
+require 'bundler/setup'
+require 'bootscale/rails'
+```
+
+### Other Bundler enabled applications
+
+Locate `require 'bundler/setup'`, and add `require 'bootscale/setup'` after it:
+
+```ruby
+require 'bundler/setup'
+require 'bootscale/setup'
 ```
 
 ## Faster cache loading
@@ -51,10 +57,10 @@ gem 'bootscale', require: false
 ```
 
 ```ruby
-# config/application.rb (or wherever you have the require of bundler/setup)
+# config/boot.rb (or wherever you have the require of bundler/setup)
 require 'bundler/setup'
 require 'msgpack'
-require 'bootscale/setup'
+require 'bootscale/setup' # or require 'bootscale/rails'
 ```
 
 ## Under the hood
@@ -66,7 +72,7 @@ Problem outlined in this [talk](https://www.youtube.com/watch?v=kwkbrOwLsZY)
 
 ## Troubleshooting
 
-If you're experiencing problems with loading your application and are unable to successfully run `Bootscale.regenerate`, try deleting the `tmp/bootscale` folder.
+If you're experiencing problems with loading your application, especially after moving files around, try deleting the `tmp/bootscale` folder.
 
 ## Contributing
 

--- a/lib/bootscale.rb
+++ b/lib/bootscale.rb
@@ -12,14 +12,14 @@ module Bootscale
       @cache_builder ||= CacheBuilder.new
     end
 
-    def setup(options = {})
-      @cache_directory = options[:cache_directory]
-      regenerate
-      require_relative 'bootscale/core_ext'
+    def regenerate
+      cache.reload
     end
 
-    def regenerate(load_path = $LOAD_PATH)
-      @cache = Cache.new(load_path, cache_directory)
+    def setup(options = {})
+      @cache_directory = options[:cache_directory]
+      @cache = Cache.new(cache_directory)
+      require_relative 'bootscale/core_ext'
     end
   end
 end

--- a/lib/bootscale.rb
+++ b/lib/bootscale.rb
@@ -6,55 +6,24 @@ module Bootscale
   LEADING_SLASH = '/'.freeze
 
   class << self
-    def [](path)
-      path = path.to_s
-      return if path.start_with?(LEADING_SLASH)
-      if path.end_with?(DOT_RB, DOT_SO)
-        @cache[path]
-      else
-        @cache["#{path}#{DOT_RB}"] || @cache["#{path}#{DOT_SO}"]
-      end
-    end
-
-    def setup(options = {})
-      self.cache_directory = options[:cache_directory]
-      require_relative 'bootscale/core_ext'
-      regenerate
-    end
-
-    def regenerate
-      @cache = load_cache || save_cache(cache_builder.generate($LOAD_PATH))
-    end
-
-    private
+    attr_reader :cache, :cache_directory
 
     def cache_builder
       @cache_builder ||= CacheBuilder.new
     end
 
-    def load_cache
-      return unless storage
-      storage.load($LOAD_PATH)
+    def setup(options = {})
+      @cache_directory = options[:cache_directory]
+      regenerate
+      require_relative 'bootscale/core_ext'
     end
 
-    def save_cache(cache)
-      return cache unless storage
-      storage.dump($LOAD_PATH, cache)
-      cache
-    end
-
-    attr_accessor :storage
-
-    def cache_directory=(directory)
-      if directory
-        require_relative 'bootscale/file_storage'
-        self.storage = FileStorage.new(directory)
-      else
-        self.storage = nil
-      end
+    def regenerate(load_path = $LOAD_PATH)
+      @cache = Cache.new(load_path, cache_directory)
     end
   end
 end
 
 require_relative 'bootscale/entry'
 require_relative 'bootscale/cache_builder'
+require_relative 'bootscale/cache'

--- a/lib/bootscale/active_support.rb
+++ b/lib/bootscale/active_support.rb
@@ -1,0 +1,40 @@
+module Bootscale
+  module ActiveSupport
+    class Cache < ::Bootscale::Cache
+      def load_path
+        ::ActiveSupport::Dependencies.autoload_paths
+      end
+
+      # Ideally we'd use a more accurate comparison like `#hash`, unfortunately it's
+      # not efficient enough given how much of a hot spot this is.
+      # So we assume entries are not mutated or replaced, only added or removed.
+      # It is obviously wrong sometimes, and you'll have to manually call Bootscale.regenerate
+      def reload(force = true)
+        @load_path_size ||= nil
+
+        if force
+          @cache = fetch(load_path)
+          @load_path_size = load_path.size
+        elsif (size = load_path.size) != @load_path_size
+          @cache = fetch(load_path)
+          @load_path_size = size
+        end
+      end
+    end
+
+    class << self
+      attr_reader :cache, :cache_directory
+
+      def cache_builder
+        @cache_builder ||= CacheBuilder.new
+      end
+
+      def setup(options = {})
+        @cache_directory = options.fetch(:cache_directory, Bootscale.cache_directory)
+        require 'active_support/dependencies'
+        @cache = Cache.new(cache_directory)
+        require_relative 'active_support/core_ext'
+      end
+    end
+  end
+end

--- a/lib/bootscale/active_support/core_ext.rb
+++ b/lib/bootscale/active_support/core_ext.rb
@@ -1,0 +1,16 @@
+require 'active_support/dependencies'
+
+module ActiveSupport
+  module Dependencies
+    undef_method :search_for_file
+
+    # ActiveSupport::Dependencies.search_for_file works pretty much like Kernel#require.
+    # It has a load path (AS::Dependencies.autoload_paths) and when it's looking for a file to load
+    # it search the load path entries one by one for a match.
+    # So just like for Kernel#require, this process is increasingly slow the more load path entries you have,
+    # and it can be optimized with exactly the same caching strategy.
+    def search_for_file(path)
+      ::Bootscale::ActiveSupport.cache[path]
+    end
+  end
+end

--- a/lib/bootscale/cache.rb
+++ b/lib/bootscale/cache.rb
@@ -1,0 +1,38 @@
+require_relative 'file_storage'
+
+module Bootscale
+  class Cache
+    attr_reader :load_path
+
+    def initialize(load_path, cache_directory = nil)
+      @load_path = load_path
+      @storage = FileStorage.new(cache_directory) if cache_directory
+      @cache = load || save(Bootscale.cache_builder.generate(load_path))
+    end
+
+    def [](path)
+      path = path.to_s
+      return if path.start_with?(LEADING_SLASH)
+      if path.end_with?(DOT_RB, DOT_SO)
+        @cache[path]
+      else
+        @cache["#{path}#{DOT_RB}"] || @cache["#{path}#{DOT_SO}"]
+      end
+    end
+
+    private
+
+    attr_reader :storage
+
+    def load
+      return unless storage
+      storage.load(load_path)
+    end
+
+    def save(cache)
+      return cache unless storage
+      storage.dump(load_path, cache)
+      cache
+    end
+  end
+end

--- a/lib/bootscale/core_ext.rb
+++ b/lib/bootscale/core_ext.rb
@@ -1,20 +1,20 @@
 module Kernel
   alias_method :require_without_cache, :require
   def require(path)
-    require_without_cache(Bootscale[path] || path)
+    require_without_cache(Bootscale.cache[path] || path)
   end
 end
 
 class << Kernel
   alias_method :require_without_cache, :require
   def require(path)
-    require_without_cache(Bootscale[path] || path)
+    require_without_cache(Bootscale.cache[path] || path)
   end
 end
 
 class Module
   alias_method :autoload_without_cache, :autoload
   def autoload(const, path)
-    autoload_without_cache(const, Bootscale[path] || path)
+    autoload_without_cache(const, Bootscale.cache[path] || path)
   end
 end

--- a/lib/bootscale/rails.rb
+++ b/lib/bootscale/rails.rb
@@ -1,0 +1,3 @@
+require_relative 'setup'
+require_relative 'active_support'
+Bootscale::ActiveSupport.setup

--- a/spec/dummy/app/models/comment.rb
+++ b/spec/dummy/app/models/comment.rb
@@ -1,0 +1,2 @@
+class Comment < ActiveRecord::Base
+end

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -1,5 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootscale'
-Bootscale.setup(cache_directory: File.expand_path('../../tmp/bootscale', __FILE__))
+require 'bootscale/rails'

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -4,9 +4,17 @@ RSpec.describe Bootscale do
   it "doesn't break application boot" do
     expect {
       Dir.chdir(File.expand_path('../dummy', __FILE__)) do
-        system("bundle exec rails r 'p 1 + 1'")
+        system('bundle', 'exec', 'rails', 'r', 'p 1 + 1')
       end
-    }.to output("2\n").to_stdout_from_any_process
+    }.to output(%{2\n}).to_stdout_from_any_process
+  end
+
+  it "doesn't break auto loading of models" do
+    expect {
+      Dir.chdir(File.expand_path('../dummy', __FILE__)) do
+        system("bundle exec rails r 'p Comment.name'")
+      end
+    }.to output(%{"Comment"\n}).to_stdout_from_any_process
   end
 
   it "can dump via msgpack" do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -90,9 +90,9 @@ RSpec.describe Bootscale do
 
         require 'bootscale/setup'
 
-        puts "not cached: \#{!!Bootscale['bundle/gems/active_support-2.1.3/foo/bar']}"
-        puts "cached 1: \#{!!Bootscale['foo/bar']}"
-        puts "cached 2: \#{!!Bootscale['bundle/baz']}"
+        puts "not cached: \#{!!Bootscale.cache['bundle/gems/active_support-2.1.3/foo/bar']}"
+        puts "cached 1: \#{!!Bootscale.cache['foo/bar']}"
+        puts "cached 2: \#{!!Bootscale.cache['bundle/baz']}"
 
         require 'foo/bar' # normal require from real load path
         require 'foo' # normal require from vendor load path


### PR DESCRIPTION
Fixes: https://github.com/byroot/bootscale/issues/26

A big mistake I made in https://github.com/byroot/bootscale/issues/26#issuecomment-135827052 is that I was profiling the development environment, where eagerloading is disabled.

As a result `search_for_file` wasn't called that much. With eager loading enabled, this change improve the boot time from `35-47s` to `29-35` seconds. Note that there is a lot of variance, both because it's a quite long operation, and also because it involves quite a bit of IOs. But even if it's hard to measure precisely the improvement, it's easy to witness it's existence.

I'll run more tests before merging this, but I don't expect much changes.