### PR TITLE
active_support required before loading part of it

### DIFF
--- a/lib/bootscale/active_support.rb
+++ b/lib/bootscale/active_support.rb
@@ -31,6 +31,7 @@ module Bootscale
 
       def setup(options = {})
         @cache_directory = options.fetch(:cache_directory, Bootscale.cache_directory)
+        require 'active_support'
         require 'active_support/dependencies'
         @cache = Cache.new(cache_directory)
         require_relative 'active_support/core_ext'


### PR DESCRIPTION
`require 'bootscale/rails'` in boot causes `undefined method `instance' for ActiveSupport::Deprecation:Class` 

`require 'active_support'` fixes it. 

expained in rails/rails#24818