### PR TITLE
Add a development mode to catch files being deleted or moved

### DIFF
--- a/lib/bootscale.rb
+++ b/lib/bootscale.rb
@@ -1,3 +1,4 @@
+require 'logger'
 require_relative 'bootscale/version'
 
 module Bootscale
@@ -7,6 +8,7 @@ module Bootscale
 
   class << self
     attr_reader :cache, :cache_directory
+    attr_accessor :logger
 
     def cache_builder
       @cache_builder ||= CacheBuilder.new
@@ -18,10 +20,13 @@ module Bootscale
 
     def setup(options = {})
       @cache_directory = options[:cache_directory]
-      @cache = Cache.new(cache_directory)
+      cache_implementation = options.fetch(:development_mode, false) ? DevelopmentCache : Cache
+      @cache = cache_implementation.new(cache_directory)
       require_relative 'bootscale/core_ext'
     end
   end
+
+  self.logger = Logger.new(STDERR)
 end
 
 require_relative 'bootscale/entry'

--- a/lib/bootscale/cache_builder.rb
+++ b/lib/bootscale/cache_builder.rb
@@ -4,13 +4,21 @@ module Bootscale
       @entries = {}
     end
 
+    def clear!
+      @entries = {}
+    end
+
     # generate the requireables cache from all current load-path entries
     # each load-path is cached individually, so new ones can be added or removed
     # but added/removed files will not be discovered
-    def generate(load_path)
+    def generate(load_path, rescan = false)
       requireables = load_path.reverse_each.flat_map do |path|
         path = path.to_s
-        entries[path] ||= Entry.new(path).requireables
+        if rescan
+          entries[path] = Entry.new(path).requireables
+        else
+          entries[path] ||= Entry.new(path).requireables
+        end
       end
       Hash[requireables]
     end

--- a/lib/bootscale/dev_rails.rb
+++ b/lib/bootscale/dev_rails.rb
@@ -1,0 +1,3 @@
+require_relative 'dev_setup'
+require_relative 'active_support'
+Bootscale::ActiveSupport.setup(development_mode: true)

--- a/lib/bootscale/dev_setup.rb
+++ b/lib/bootscale/dev_setup.rb
@@ -1,0 +1,2 @@
+require 'bootscale'
+Bootscale.setup(cache_directory: 'tmp/bootscale', development_mode: true)

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+RSpec.describe 'caches' do
+  let(:files) do
+    %w(
+      a/foo.rb
+      b/foo.rb
+      b/bar.rb
+    )
+  end
+
+  let(:load_path) { %w(a b).map { |d| File.join(tmpdir, d) } }
+
+  let!(:tmpdir) { Dir.mktmpdir }
+
+  before do
+    allow_any_instance_of(described_class).to receive(:load_path).and_return(load_path)
+    Bootscale.cache_builder.clear!
+    files.each do |relative_path|
+      absolute_path = File.join(tmpdir, relative_path)
+      FileUtils.mkdir_p(File.dirname(absolute_path))
+      File.write(absolute_path, '')
+    end
+  end
+
+  after do
+    FileUtils.rm_rf(tmpdir)
+  end
+
+  subject { described_class.new(load_path) }
+
+  describe Bootscale::Cache do
+    it 'returns the absolute path' do
+      expect(subject['foo.rb']).to be_an_absolute_path
+    end
+
+    it 'returns nil on miss' do
+      expect(subject['plop.rb']).to be_nil
+    end
+
+    it "doesn't catch changes on the file system" do
+      expect {
+        File.delete(subject['foo.rb'])
+      }.to_not change { subject['foo.rb'] }
+
+      expect {
+        File.write(File.join(tmpdir, 'a', 'bar.rb'), '')
+      }.to_not change { subject['bar.rb'] }
+    end
+  end
+
+  describe Bootscale::DevelopmentCache do
+    it 'returns the absolute path' do
+      expect(subject['foo.rb']).to be_an_absolute_path
+    end
+
+    it 'returns nil on miss' do
+      expect(subject['plop.rb']).to be_nil
+    end
+
+    it 'automatically regenerates when a cached path is moved or deleted' do
+      expect {
+        File.delete(subject['foo.rb'])
+      }.to change { subject['foo.rb'] }
+    end
+
+    it 'automatically regenerates when a new path overrides a cached one' do
+      pending "This case isn't supported. Yet? Maybe with an inotify integration?"
+      expect {
+        File.write(File.join(tmpdir, 'a', 'bar.rb'), '')
+      }.to change { subject['bar.rb'] }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ require 'tmpdir'
 
 Dir[File.expand_path('../support/**/*.rb', __FILE__)].each { |f| require f }
 
+Bootscale.logger = Logger.new(nil)
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/support/paths_helper.rb
+++ b/spec/support/paths_helper.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :be_an_absolute_path do
+  match do |actual|
+    actual && actual == File.expand_path(actual)
+  end
+end


### PR DESCRIPTION
As discussed. In development, it can happen that a requirable file is deleted or moved from a load path entry to another.

This fix isn't perfect, there is still edge cases that can trick it (as outlines in the pending test), but it should still be better than what we have now. 

@kirs for review please.